### PR TITLE
Add INDEX file for updates & upgrades

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -1,0 +1,9 @@
+{
+    "bind": {
+        "MANIFEST": "bookstack.json",
+        "description": "Bookstack wiki",
+        "name": "Bookstack",
+        "official": false,
+        "primary_pkg": null
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ This plugin is experimental. It seems to work, but pull requests are welcome.
 
 # Install
 
-Clone this repository on your FreeNAS server, then run the following command to create a new jail with it.
+Clone this repository on your FreeNAS / TrueNAS core server, then run the following command to create a new jail with it.
 
 ```
-iocage fetch -P bookstack.json --name bookstack dhcp="on"
+iocage fetch -g https://github.com/Adirael/iocage-plugin-bookstack -P bookstack.json --name bookstack dhcp="on"
 ``` 
+
+If your installation was done by manually downloading the plugin files, set the plugin_repository property to this repo like
+
+```
+iocage set plugin_repository=ttps://github.com/Adirael/iocage-plugin-bookstack bookstack
+```
+
+to revieve updates.

--- a/bookstack.json
+++ b/bookstack.json
@@ -1,7 +1,7 @@
 {
   "name": "bookstack",
   "plugin_schema": "2",
-  "artifact": "https://github.com/Adirael/iocage-plugin-bookstack.git",
+  "artifact": "https://github.com/sam-harry/iocage-plugin-bookstack",
   "release": "12.2-RELEASE",
   "pkgs": [
     "php74", "php74-mbstring", "php74-tokenizer", "php74-pdo", "php74-pdo_mysql",

--- a/bookstack.json
+++ b/bookstack.json
@@ -1,7 +1,7 @@
 {
   "name": "bookstack",
   "plugin_schema": "2",
-  "artifact": "https://github.com/Adirael/iocage-plugin-bookstack",
+  "artifact": "https://github.com/Adirael/iocage-plugin-bookstack.git",
   "release": "12.2-RELEASE",
   "pkgs": [
     "php74", "php74-mbstring", "php74-tokenizer", "php74-pdo", "php74-pdo_mysql",

--- a/bookstack.json
+++ b/bookstack.json
@@ -1,7 +1,7 @@
 {
   "name": "bookstack",
   "plugin_schema": "2",
-  "artifact": "https://github.com/sam-harry/iocage-plugin-bookstack",
+  "artifact": "https://github.com/Adirael/iocage-plugin-bookstack",
   "release": "12.2-RELEASE",
   "pkgs": [
     "php74", "php74-mbstring", "php74-tokenizer", "php74-pdo", "php74-pdo_mysql",

--- a/bookstack.json
+++ b/bookstack.json
@@ -2,7 +2,7 @@
   "name": "bookstack",
   "plugin_schema": "2",
   "artifact": "https://github.com/Adirael/iocage-plugin-bookstack.git",
-  "release": "12.1-RELEASE",
+  "release": "12.2-RELEASE",
   "pkgs": [
     "php74", "php74-mbstring", "php74-tokenizer", "php74-pdo", "php74-pdo_mysql",
   "php74-openssl", "php74-json", "php74-phar", "php74-filter",


### PR DESCRIPTION
Using the manual installation method prevents the iocage plugin from updating & upgrading as it does not have a repository to pull from.

Please consider these changes to allow for updating & upgrading the plugin.

I suppose these changes could also be modified & integrated into the iocage-hub to make it available through the GUI.